### PR TITLE
compileWidgets task fails on Windows #3

### DIFF
--- a/src/main/groovy/io/jmix/gradle/ui/WidgetsCompile.java
+++ b/src/main/groovy/io/jmix/gradle/ui/WidgetsCompile.java
@@ -17,8 +17,10 @@
 package io.jmix.gradle.ui;
 
 import com.google.common.base.Joiner;
+import io.jmix.gradle.ClassPathUtil;
 import io.jmix.gradle.JmixPlugin;
 import org.apache.commons.io.FileUtils;
+import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -72,6 +74,8 @@ public class WidgetsCompile extends WidgetsTask {
     protected String xss = "-Xss8m";
 
     protected String logLevel = "ERROR";
+
+    protected boolean shortClassPath = false;
 
     protected int workers = Math.max(Runtime.getRuntime().availableProcessors() - 1, 1);
 
@@ -133,12 +137,25 @@ public class WidgetsCompile extends WidgetsTask {
             generateWidgetSetXml(compilerClassPath, gwtTemp, widgetSetClass);
         }
 
-        getProject().javaexec(spec -> {
-            spec.setMain("com.google.gwt.dev.Compiler");
-            spec.setClasspath(getProject().files(compilerClassPath));
-            spec.setArgs(gwtCompilerArgs);
-            spec.setJvmArgs(gwtCompilerJvmArgs);
-        });
+        if (Os.isFamily(Os.FAMILY_WINDOWS) && shortClassPath) {
+            File classPathFile = getProject().file("build/tmp/compile-widget-set-classpath.dat");
+            ClassPathUtil.createClassPathFile(classPathFile, compilerClassPath);
+
+            getProject().javaexec(spec -> {
+                spec.setMain("io.jmix.gradle.ClassPathCommandLine");
+                spec.setClasspath(getProject().files(ClassPathUtil.getCommandLineClassPath()));
+                spec.setArgs(ClassPathUtil.getExtendedCommandLineAgs(
+                        classPathFile.getAbsolutePath(), "com.google.gwt.dev.Compiler", gwtCompilerArgs));
+                spec.setJvmArgs(gwtCompilerJvmArgs);
+            });
+        } else {
+            getProject().javaexec(spec -> {
+                spec.setMain("com.google.gwt.dev.Compiler");
+                spec.setClasspath(getProject().files(compilerClassPath));
+                spec.setArgs(gwtCompilerArgs);
+                spec.setJvmArgs(gwtCompilerJvmArgs);
+            });
+        }
 
         deleteQuietly(new File(gwtWidgetSetTemp, "WEB-INF"));
 
@@ -499,6 +516,14 @@ public class WidgetsCompile extends WidgetsTask {
 
     public String getLogLevel() {
         return logLevel;
+    }
+
+    public boolean isShortClassPath() {
+        return shortClassPath;
+    }
+
+    public void setShortClassPath(boolean shortenClassPath) {
+        this.shortClassPath = shortenClassPath;
     }
 
     public void setWorkers(int workers) {

--- a/src/main/groovy/io/jmix/gradle/ui/WidgetsCompile.java
+++ b/src/main/groovy/io/jmix/gradle/ui/WidgetsCompile.java
@@ -75,7 +75,7 @@ public class WidgetsCompile extends WidgetsTask {
 
     protected String logLevel = "ERROR";
 
-    protected boolean shortClassPath = false;
+    protected boolean shortClassPath = true;
 
     protected int workers = Math.max(Runtime.getRuntime().availableProcessors() - 1, 1);
 

--- a/src/main/groovy/io/jmix/gradle/ui/WidgetsDebug.java
+++ b/src/main/groovy/io/jmix/gradle/ui/WidgetsDebug.java
@@ -42,7 +42,7 @@ public class WidgetsDebug extends WidgetsTask {
 
     protected boolean printCompilerClassPath = false;
 
-    protected boolean shortClassPath = false;
+    protected boolean shortClassPath = true;
 
     protected String logLevel = "INFO";
 

--- a/src/main/groovy/io/jmix/gradle/ui/WidgetsDebug.java
+++ b/src/main/groovy/io/jmix/gradle/ui/WidgetsDebug.java
@@ -16,6 +16,8 @@
 
 package io.jmix.gradle.ui;
 
+import io.jmix.gradle.ClassPathUtil;
+import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ResolvedArtifact;
@@ -39,6 +41,8 @@ public class WidgetsDebug extends WidgetsTask {
     protected Map<String, Object> compilerArgs = new HashMap<>();
 
     protected boolean printCompilerClassPath = false;
+
+    protected boolean shortClassPath = false;
 
     protected String logLevel = "INFO";
 
@@ -73,12 +77,31 @@ public class WidgetsDebug extends WidgetsTask {
         List<String> gwtCompilerArgs = collectCompilerArgs();
         List<String> gwtCompilerJvmArgs = collectCompilerJvmArgs();
 
-        getProject().javaexec(javaExecSpec -> {
-            javaExecSpec.setMain("com.google.gwt.dev.codeserver.CodeServer");
-            javaExecSpec.setClasspath(getProject().files(compilerClassPath));
-            javaExecSpec.setArgs(gwtCompilerArgs);
-            javaExecSpec.setJvmArgs(gwtCompilerJvmArgs);
-        });
+        if (Os.isFamily(Os.FAMILY_WINDOWS) && shortClassPath) {
+            File javaTmp = getProject().file("build/tmp/");
+            if (javaTmp.exists()) {
+                FileUtils.deleteQuietly(javaTmp);
+            }
+            javaTmp.mkdirs();
+
+            File classPathFile = getProject().file("build/tmp/debug-widget-set-classpath.dat");
+            ClassPathUtil.createClassPathFile(classPathFile, compilerClassPath);
+
+            getProject().javaexec(spec -> {
+                spec.setMain("io.jmix.gradle.ClassPathCommandLine");
+                spec.setClasspath(getProject().files(ClassPathUtil.getCommandLineClassPath()));
+                spec.setArgs(ClassPathUtil.getExtendedCommandLineAgs(
+                        classPathFile.getAbsolutePath(), "com.google.gwt.dev.codeserver.CodeServer", gwtCompilerArgs));
+                spec.setJvmArgs(gwtCompilerJvmArgs);
+            });
+        } else {
+            getProject().javaexec(javaExecSpec -> {
+                javaExecSpec.setMain("com.google.gwt.dev.codeserver.CodeServer");
+                javaExecSpec.setClasspath(getProject().files(compilerClassPath));
+                javaExecSpec.setArgs(gwtCompilerArgs);
+                javaExecSpec.setJvmArgs(gwtCompilerJvmArgs);
+            });
+        }
     }
 
     @InputFiles
@@ -246,6 +269,14 @@ public class WidgetsDebug extends WidgetsTask {
 
     public boolean isPrintCompilerClassPath() {
         return printCompilerClassPath;
+    }
+
+    public boolean isShortClassPath() {
+        return shortClassPath;
+    }
+
+    public void setShortClassPath(boolean shortClassPath) {
+        this.shortClassPath = shortClassPath;
     }
 
     public void setLogLevel(String logLevel) {

--- a/src/main/java/io/jmix/gradle/ClassPathCommandLine.java
+++ b/src/main/java/io/jmix/gradle/ClassPathCommandLine.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2020 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.gradle;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ClassPathCommandLine {
+
+    public static void main(String[] args) {
+        List<String> classPath = readAndRemoveFile(args[0]);
+
+        ClassLoader classLoader = buildClassLoader(classPath);
+        Thread.currentThread().setContextClassLoader(classLoader);
+
+        System.setProperty("java.class.path", StringUtils.join(classPath, ";"));
+
+        //System.setProperty("java.class.path",
+        //        StringUtils.join(classPath, SystemUtils.IS_OS_WINDOWS ? ";" : ":"));
+
+        invokeOriginalMainClass(classLoader, args[1], getOriginalArgs(args));
+    }
+
+    private static void invokeOriginalMainClass(ClassLoader classLoader, String mainClass, String[] args) {
+        try {
+            Class<?> cls = classLoader.loadClass(mainClass);
+            Method mainMethod = cls.getMethod("main", String[].class);
+            mainMethod.invoke(null, new Object[]{args});
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Unable to run Main-Class:" + mainClass, e);
+        }
+    }
+
+    private static String[] getOriginalArgs(String[] args) {
+        if (args != null) {
+            return ArrayUtils.subarray(args, 2, args.length);
+        }
+        return new String[0];
+    }
+
+    private static ClassLoader buildClassLoader(List<String> classPath) {
+        List<URL> urls = new ArrayList<>();
+        try {
+            for (String str : classPath) {
+                urls.add(new File(str).toURI().toURL());
+            }
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Unable to build classpath:", e);
+        }
+        return new URLClassLoader(urls.toArray(new URL[0]), null);
+    }
+
+    private static List<String> readAndRemoveFile(String path) {
+        List<String> lines;
+        try {
+            lines = FileUtils.readLines(new File(path), Charset.defaultCharset());
+            FileUtils.deleteQuietly(new File(path));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return lines;
+    }
+}

--- a/src/main/java/io/jmix/gradle/ClassPathUtil.java
+++ b/src/main/java/io/jmix/gradle/ClassPathUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2020 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.gradle;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ClassPathUtil {
+
+    public static void createClassPathFile(File classPathFile, List<File> classPath) {
+        try (PrintWriter writer = new PrintWriter(classPathFile)) {
+            for (File file : classPath) {
+                writer.println(file.getAbsolutePath());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write classpath to temporary file", e);
+        }
+    }
+
+    public static List<File> getCommandLineClassPath() {
+        ClassLoader classLoader = ClassPathCommandLine.class.getClassLoader();
+        if (classLoader instanceof URLClassLoader) {
+            URL[] urls = ((URLClassLoader) (ClassPathCommandLine.class.getClassLoader())).getURLs();
+            return Arrays.stream(urls)
+                    .map(url -> new File(url.getPath()))
+                    .collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+
+    public static List<String> getExtendedCommandLineAgs(String classPathFile, String mainClass, List<String> args) {
+        List<String> extendedArgs = new ArrayList<>();
+
+        extendedArgs.add(classPathFile);
+        extendedArgs.add(mainClass);
+        extendedArgs.addAll(args);
+
+        return extendedArgs;
+    }
+}


### PR DESCRIPTION
See #3
@andreysubbotin, what do you think about making `shortClassPath = true` by default for Windows?
Because, the issue is reproduced on a small project containing only jmix-maps. So there is a high chance that every Windows user will have to specify this property.